### PR TITLE
add style guide emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Using CREG (Code Review Emoji Guide) puts more ownership on the reviewer to give
 |   ♻️   |           `:recycle:`            | Suggestion for refactoring. <br /><br /> Should include enough context to be actionable and not be considered a nitpick.                                                                                                                        |
 |   🏕    |           `:camping:`            | Here is an opportunity, not directly related to your changes, for us to leave the campground [code] cleaner than we found it.                                                                                                                   |
 |   📌   |           `:pushpin:`            | This is a concern that is _out of scope_ and should be staged appropriately for follow up.                                                                                                                                                      |
-|   📝   |             `:memo:`             | This points out a change that should be made to bring code in line with an accepted style guide.                                                                                                                                                |
+|   🎩   |             `:memo:`             | This points out a change that should be made to bring code in line with an accepted style guide.                                                                                                                                                |
 
 ## Usage
 
@@ -44,7 +44,7 @@ Prepend comments with the appropriate emoji to convey the meaning associated wit
 
 > 📌 We really need to invest some time in refactoring out our use of this deprecated library. _Issue created: [LINK TO ISSUE]_.
 
-> 📝 This error should not be left unchecked.
+> 🎩 This error should not be left unchecked.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Using CREG (Code Review Emoji Guide) puts more ownership on the reviewer to give
 |   ♻️   |           `:recycle:`            | Suggestion for refactoring. <br /><br /> Should include enough context to be actionable and not be considered a nitpick.                                                                                                                        |
 |   🏕    |           `:camping:`            | Here is an opportunity, not directly related to your changes, for us to leave the campground [code] cleaner than we found it.                                                                                                                   |
 |   📌   |           `:pushpin:`            | This is a concern that is _out of scope_ and should be staged appropriately for follow up.                                                                                                                                                      |
-|   🎩   |             `:memo:`             | This points out a change that should be made to bring code in line with an accepted style guide.                                                                                                                                                |
+|   🎩   |            `:tophat:`            | This points out a change that should be made to bring code in line with an accepted style guide.                                                                                                                                                |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,18 +10,19 @@ Using CREG (Code Review Emoji Guide) puts more ownership on the reviewer to give
 
 ## Emoji Legend
 
-|     |   `:code:`   | Meaning                                                                                                                                                                             |
-| :-: | :----------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 😃👍💯  |  `:smiley:` `:+1:` `:100:`  | I like this... <br /><br /> ...and I want the author to know it! This is a way to highlight positive parts of a code review.                                                        |
-| 🔧  |  `:wrench:`  | I think this needs to be changed. <br /><br />This is a concern or suggested change/refactor that I feel is worth addressing.                                                       |
-| ❓  | `:question:` | I have a question. <br /><br /> This should be a fully formed question with sufficient information and context that requires a response.                                            |
-| 🤔💭 | `:thinking:` `:thought_balloon:` | Let me think out loud here for a minute. <br /><br /> I might express concern, suggest an alternative solution, or walk through the code in my own words to make sure I understand. |
-| 🌱  | `:seedling:` | Planting a seed for future. <br /><br /> An observation or suggestion that is not a change request, but may have larger implications. Generally something to keep in mind for the future. |
-| 📝  |   `:memo:`   | This is an explanatory note, fun fact, or relevant commentary that does not require any action.                                                                                     |
-|  ⛏  |   `:pick:`   | This is a nitpick. <br /><br /> This does not require any changes and is often better left unsaid. This may include stylistic, formatting, or organization suggestions and should likely be prevented/enforced by linting if they really matter |
-|  ♻️  | `:recycle:`  | Suggestion for refactoring. <br /><br /> Should include enough context to be actionable and not be considered a nitpick. |
-|  🏕  | `:camping:`  | Here is an opportunity, not directly related to your changes, for us to leave the campground [code] cleaner than we found it.                                                       |
-| 📌  | `:pushpin:`  | This is a concern that is _out of scope_ and should be staged appropriately for follow up.                                                                                          |
+|        |             `:code:`             | Meaning                                                                                                                                                                                                                                         |
+| :----: | :------------------------------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 😃👍💯 |    `:smiley:` `:+1:` `:100:`     | I like this... <br /><br /> ...and I want the author to know it! This is a way to highlight positive parts of a code review.                                                                                                                    |
+|   🔧   |            `:wrench:`            | I think this needs to be changed. <br /><br />This is a concern or suggested change/refactor that I feel is worth addressing.                                                                                                                   |
+|   ❓   |           `:question:`           | I have a question. <br /><br /> This should be a fully formed question with sufficient information and context that requires a response.                                                                                                        |
+|  🤔💭  | `:thinking:` `:thought_balloon:` | Let me think out loud here for a minute. <br /><br /> I might express concern, suggest an alternative solution, or walk through the code in my own words to make sure I understand.                                                             |
+|   🌱   |           `:seedling:`           | Planting a seed for future. <br /><br /> An observation or suggestion that is not a change request, but may have larger implications. Generally something to keep in mind for the future.                                                       |
+|   📝   |             `:memo:`             | This is an explanatory note, fun fact, or relevant commentary that does not require any action.                                                                                                                                                 |
+|   ⛏    |             `:pick:`             | This is a nitpick. <br /><br /> This does not require any changes and is often better left unsaid. This may include stylistic, formatting, or organization suggestions and should likely be prevented/enforced by linting if they really matter |
+|   ♻️   |           `:recycle:`            | Suggestion for refactoring. <br /><br /> Should include enough context to be actionable and not be considered a nitpick.                                                                                                                        |
+|   🏕    |           `:camping:`            | Here is an opportunity, not directly related to your changes, for us to leave the campground [code] cleaner than we found it.                                                                                                                   |
+|   📌   |           `:pushpin:`            | This is a concern that is _out of scope_ and should be staged appropriately for follow up.                                                                                                                                                      |
+|   📝   |             `:memo:`             | This points out a change that should be made to bring code in line with an accepted style guide.                                                                                                                                                |
 
 ## Usage
 
@@ -43,13 +44,15 @@ Prepend comments with the appropriate emoji to convey the meaning associated wit
 
 > 📌 We really need to invest some time in refactoring out our use of this deprecated library. _Issue created: [LINK TO ISSUE]_.
 
+> 📝 This error should not be left unchecked.
+
 ---
 
 ### Credits
 
 Partially inspired by
 
-* http://dawehner.github.io/github,/code/review/2017/09/08/emoji-code-review.html
-* https://gist.github.com/pfleidi/4422a5cac5b04550f714f1f886d2feea
-* https://twitter.com/JackieCalaprist/status/981557821308153856
-* https://github.com/carloscuesta/gitmoji/
+- http://dawehner.github.io/github,/code/review/2017/09/08/emoji-code-review.html
+- https://gist.github.com/pfleidi/4422a5cac5b04550f714f1f886d2feea
+- https://twitter.com/JackieCalaprist/status/981557821308153856
+- https://github.com/carloscuesta/gitmoji/


### PR DESCRIPTION
This adds another emoji for pointing out changes that should be made to align code with a style guide.

I feel this to be necessary because, while it can feel like a nitpick, keeping to established style guides should be a required change. But it also shouldn't require much discussion, so the emoji should indicate this specific intent.

Also, prettier hit the doc with some formatting.